### PR TITLE
change rpmbuild required package to rpm-build

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -93,7 +93,7 @@ installed on your system:
 
 ::
 
-    $ yum install gcc rpmbuild rpm-devel rpmlint make python bash coreutils diffutils
+    $ yum install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils
     patch
 
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -86,7 +86,7 @@ installed on your system:
 
 ::
 
-    $ dnf install gcc rpmbuild rpm-devel rpmlint make python bash coreutils diffutils
+    $ dnf install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils
     patch
 
 * For `RHEL`_ or `CentOS`_ (this guide assumes version 7.x of either):


### PR DESCRIPTION
Fedora package is rpm-build for F24. Probably the same for RHEL/Cent, but did not check.
